### PR TITLE
Don't override Trice.support_requested_at_stubbing

### DIFF
--- a/lib/trice/railtie.rb
+++ b/lib/trice/railtie.rb
@@ -1,7 +1,9 @@
 module Trice
   class Railtie < ::Rails::Railtie
     initializer 'trice' do |app|
-      Trice.support_requested_at_stubbing = !Rails.env.production?
+      if Trice.support_requested_at_stubbing.nil?
+        Trice.support_requested_at_stubbing = !Rails.env.production?
+      end
     end
   end
 end


### PR DESCRIPTION
If set before initializer('trice') ran, the setting was overwritten