### PR TITLE
Handle out of action exception

### DIFF
--- a/lib/trice/controller_methods.rb
+++ b/lib/trice/controller_methods.rb
@@ -1,3 +1,4 @@
+require 'trice/controller_methods/raw_reference_time'
 require 'trice/controller_methods/reference_time_assignment'
 require 'trice/controller_methods/stub_configuration'
 
@@ -8,6 +9,8 @@ module Trice
 
     included do |controller|
       if controller.ancestors.include?(ActionController::Base)
+        use RawReferenceTime
+
         config = StubConfiguration.new(Trice.support_requested_at_stubbing)
         prepend_around_action ReferenceTimeAssignment.new(config)
 

--- a/lib/trice/controller_methods.rb
+++ b/lib/trice/controller_methods.rb
@@ -9,7 +9,9 @@ module Trice
 
     included do |controller|
       if controller.ancestors.include?(ActionController::Base)
-        use RawReferenceTime
+        unless controller.middleware_stack.include?(RawReferenceTime)
+          controller.use RawReferenceTime
+        end
 
         config = StubConfiguration.new(Trice.support_requested_at_stubbing)
         prepend_around_action ReferenceTimeAssignment.new(config)

--- a/lib/trice/controller_methods/raw_reference_time.rb
+++ b/lib/trice/controller_methods/raw_reference_time.rb
@@ -1,0 +1,17 @@
+module Trice
+  module ControllerMethods
+    class RawReferenceTime
+      ENV_KEY = 'trice.raw_reference_time'.freeze
+
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env[ENV_KEY] = Time.now
+
+        Trice.with_reference_time(env[ENV_KEY]) { @app.call(env) }
+      end
+    end
+  end
+end

--- a/lib/trice/controller_methods/reference_time_assignment.rb
+++ b/lib/trice/controller_methods/reference_time_assignment.rb
@@ -12,8 +12,6 @@ module Trice
       def around(controller, &action)
         t = determine_requested_at(controller)
 
-        controller.request.env['trice.reference_time'] = t
-
         Trice.with_reference_time(t, &action)
       end
 

--- a/spec/support/trice_controller_method_test_controller.rb
+++ b/spec/support/trice_controller_method_test_controller.rb
@@ -16,16 +16,34 @@ app.config.root = File.expand_path('../fake_rails_app', (__FILE__))
 Rails.backtrace_cleaner.remove_silencers!
 app.initialize!
 app.routes.draw do
-  get 'hi', to: 'trice_controller_method_test#hi'
+  get 'hi',   to: 'trice_controller_method_test#hi'
+  get 'bang', to: 'trice_controller_method_test#bang'
 end
+
+TriceTestError = Class.new(StandardError)
 
 class TriceControllerMethodTestController < ActionController::Base
   include Trice::ControllerMethods
+
+  before_action :raise_rescued_exception, only: 'bang'
+
+  rescue_from TriceTestError do
+    render json: {expected_requested_at: requested_at}, status: 400
+  end
 
   def hi
     @requested_at_x  = requested_at
     @requested_at_y  = requested_at
 
-    render nothing: true
+    render json: {requested_at_x: @requested_at_x, requested_at_y: @requested_at_y}
+  end
+
+  def bang
+  end
+
+  private
+
+  def raise_rescued_exception
+    raise TriceTestError
   end
 end

--- a/spec/trice/controller_methods_spec.rb
+++ b/spec/trice/controller_methods_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 require 'trice_controller_method_test_controller'
 
+describe 'TriceControllerMethodTestController E2E', type: :request do
+  scenario 'hi' do
+    get '/bang'
+
+    expect(response.status).to eq 400
+
+    p JSON.parse(response.body)
+  end
+end
+
 describe TriceControllerMethodTestController, type: :controller do
   describe '#requested_at should be same time' do
     before do

--- a/spec/trice/controller_methods_spec.rb
+++ b/spec/trice/controller_methods_spec.rb
@@ -6,8 +6,6 @@ describe 'TriceControllerMethodTestController E2E', type: :request do
     get '/bang'
 
     expect(response.status).to eq 400
-
-    p JSON.parse(response.body)
   end
 end
 


### PR DESCRIPTION
A exception raised in filter before skips Trice's around_filter.
It cause another `Trice::NoReferenceTime` errors if the error page rendered from `rescue_from` section that catches the exception raised in filter.

This PR fixes the problem by specifying `trice.raw_reference_time` in Rack layer, which is called before Rails controller before/around action callbacks.