### PR TITLE
Refactoring trice spec_helper tests

### DIFF
--- a/spec/trice/spec_helper_spec.rb
+++ b/spec/trice/spec_helper_spec.rb
@@ -1,17 +1,26 @@
 require 'spec_helper'
 
 describe Trice::SpecHelper do
-  describe 'stub_requested_at raises error for not supported type', type: :hi do
+  describe 'stub_requested_at raises error for not supported type' do
+    let(:example_group) do
+      RSpec.describe('stub_requested_at_not_supported_example', type: :hi) do
+        extend Trice::SpecHelper
 
-    stub_requested_at
+        stub_requested_at
 
-    around do |example|
-      example.run
-      expect(example.exception).to be_a(Trice::TestStubbingNotSupported)
-      expect(example.exception.message).to eq 'Test stubbing for type: hi is not supported'
-      skip
+        specify { 'do something' }
+      end
     end
 
-    specify { 'raises error for not supported type' }
+    let(:example) { example_group.examples.first }
+
+    before do
+      example_group.run
+    end
+
+    specify do
+      expect(example.exception).to be_a(Trice::TestStubbingNotSupported)
+      expect(example.exception.message).to eq 'Test stubbing for type: hi is not supported'
+    end
   end
 end


### PR DESCRIPTION
Build isolated rspec example example to test `trice/spec_helper`.

 cc @hanachin 