### PR TITLE
StubConfiguration#stubbable? is not evaluated without stubbed requested-at

### DIFF
--- a/lib/trice/controller_methods/reference_time_assignment.rb
+++ b/lib/trice/controller_methods/reference_time_assignment.rb
@@ -10,27 +10,23 @@ module Trice
       end
 
       def around(controller, &action)
-        t = determine_requested_at(controller)
+        t = stubbed_requested_at(controller) || Time.now
 
         Trice.with_reference_time(t, &action)
       end
 
       private
 
-      def determine_requested_at(controller)
-        if @stub_configuration.stubbable?(controller)
-          extract_requested_at(controller.request) || Time.now
-        else
-          Time.now
+      def stubbed_requested_at(controller)
+        requested_at = requested_at_string(controller.request)
+
+        if requested_at && @stub_configuration.stubbable?(controller)
+          Time.zone.parse(requested_at)
         end
       end
 
-      def extract_requested_at(request)
-        if request.params[QUERY_STUB_KEY]
-          Time.zone.parse(request.params[QUERY_STUB_KEY])
-        elsif request.headers[HEADER_STUB_KEY]
-          Time.zone.parse(request.headers[HEADER_STUB_KEY])
-        end
+      def requested_at_string(request)
+        request.params[QUERY_STUB_KEY] || request.headers[HEADER_STUB_KEY]
       end
     end
   end

--- a/spec/trice/controller_methods_spec.rb
+++ b/spec/trice/controller_methods_spec.rb
@@ -39,6 +39,16 @@ describe TriceControllerMethodTestController, type: :controller do
       specify { expect(assigns(:requested_at_x)).to eq time }
     end
 
+    context 'StubConfiguration#stubbable? is not evaluated without stubbed by param or header' do
+      before do
+        expect_any_instance_of(Trice::ControllerMethods::StubConfiguration).not_to receive(:stubbable?)
+
+        get :hi
+      end
+
+      specify { expect(assigns(:requested_at_x)).to be_acts_like(:time) }
+    end
+
     context 'stubbed by helper method (static)' do
       t = Time.now
       stub_requested_at t


### PR DESCRIPTION
To reduce `stubble?` overhead, look into params or header at first.
Please review this.