### PR TITLE
Update tested Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
   - ruby-head
 gemfile:
   - gemfiles/rails_4_2.gemfile


### PR DESCRIPTION
- Ruby 2.2 is no longer maintained https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-2-10-released/
    - Latest capybara also dropped Ruby 2.2 support https://travis-ci.org/cookpad/trice/builds/394391188
- Add Ruby 2.5

@cookpad/dev-infra @moro please review